### PR TITLE
JSON autoescape isn't JSON

### DIFF
--- a/templates/JSON/documents.tpl
+++ b/templates/JSON/documents.tpl
@@ -9,7 +9,7 @@
                           "fragments" : [{{#FRAGMENT}}[{{FROM}},{{TO}},{{LENGTH}},{{HASH}}]{{#FRAGMENT_separator}},{{/FRAGMENT_separator}}{{/FRAGMENT}}],
                           {{/FRAGMENTS}}
                           {{#META}}
-                          "{{KEY}}": {{#NUMBER}}{{VALUE}}{{/NUMBER}}{{#STRING}}"{{VALUE}}"{{/STRING}}{{#DATE}}new Date({{VALUE}}){{/DATE}}{{#META_separator}},{{/META_separator}}
+                          "{{KEY}}": {{#NUMBER}}{{VALUE}}{{/NUMBER}}{{#STRING}}"{{VALUE:json_escape}}"{{/STRING}}{{#DATE}}{{VALUE}}{{/DATE}}{{#META_separator}},{{/META_separator}}
                           {{/META}}
                         }{{#DOCUMENT_separator}},{{/DOCUMENT_separator}}
                         {{/DOCUMENT}}

--- a/templates/JSON/search.tpl
+++ b/templates/JSON/search.tpl
@@ -3,5 +3,5 @@
         {{>DOCUMENTS}}
     },
     {{#SOURCE}}
-    "text"      : "{{TEXT}}"
+    "text"      : "{{TEXT:json_escape}}"
 {{/SOURCE}}


### PR DESCRIPTION
The JSON API responses had \x character escapes in the strings, which is invalid JSON. I tracked this back to the SFM JSON templates. They use ctemplate's JSON autoescaping which actually uses the :javascript_escape modifier rather than the :json_escape modifier. Using :json_escape spits out the proper \u unicode character escapes.

I also removed the new Date(<timestamp>) in favor of a integer or string literal. While the Date constructor works in Javascript, it's not valid JSON and it makes it a headache to consume in other languages.
